### PR TITLE
URI rewrite and content-length fixes

### DIFF
--- a/ocsp.go
+++ b/ocsp.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -83,7 +84,10 @@ func (m *middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// See https://datatracker.ietf.org/doc/html/rfc6960#appendix-A.1
 	r.Method = http.MethodPost
 	r.URL.Path = prefix
+	r.RequestURI = prefix
 	r.Header.Set("Content-Type", "application/ocsp-request")
+	r.Header.Set("Content-Length", strconv.Itoa(len(data)))
+	r.ContentLength = int64(len(data))
 	r.Body = io.NopCloser(bytes.NewReader(data))
 
 	m.next.ServeHTTP(w, r)

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	plug "github.com/project-echo/traefik-ocsp"
@@ -210,8 +211,17 @@ func assertOcspRequest(t *testing.T, handler http.Handler, prefix string, p payl
 	if req.URL.Path != prefix {
 		t.Errorf("req.URL.Path = %s; want %s", req.URL.Path, prefix)
 	}
+	if req.RequestURI != prefix {
+		t.Errorf("req.RequestURI = %s; want %s", req.RequestURI, prefix)
+	}
+
+	contentLength := int64(len(p.bytes))
+	if req.ContentLength != contentLength {
+		t.Errorf("req.ContentLength = %d; want %d", req.ContentLength, contentLength)
+	}
 
 	assertHeader(t, req, "Content-Type", "application/ocsp-request")
+	assertHeader(t, req, "Content-Length", strconv.FormatInt(contentLength, 10))
 
 	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {


### PR DESCRIPTION
After testing turned out just setting `r.URL.Path` is not enough, raw `r.RequestURI` is what is passed on to the service.

Also when setting body, need to set `r.ContentLength` and header as well, for body content to be properly passed forward to service.